### PR TITLE
修复和优化了一些羁绊相关问题

### DIFF
--- a/src/main/java/demoMod/icebreaker/actions/SelectCardInCardGroupAction.java
+++ b/src/main/java/demoMod/icebreaker/actions/SelectCardInCardGroupAction.java
@@ -8,6 +8,8 @@ import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import demoMod.icebreaker.IceBreaker;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -45,18 +47,21 @@ public class SelectCardInCardGroupAction extends AbstractGameAction {
             }
             temp.sortAlphabetically(true);
             temp.sortByRarityPlusStatusCardType(false);
-            AbstractDungeon.gridSelectScreen.open(temp, this.amount, String.format(TEXT[0], this.amount), false);
-            tickDuration();
-            return;
+            AbstractDungeon.gridSelectScreen.open(temp, this.amount, true, String.format(TEXT[0], this.amount));
+            tickDuration(); return;
         }
 
-        if (!AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
+        // modified here
+        if (AbstractDungeon.screen != AbstractDungeon.CurrentScreen.GRID) {
+            // logger.info(AbstractDungeon.gridSelectScreen.selectedCards.size() + "!!!!!!!!!!!!");
             for (AbstractCard c : AbstractDungeon.gridSelectScreen.selectedCards) {
                 this.action.accept(c);
+                // logger.info(c.cardID + " " + c.uuid);
             }
             AbstractDungeon.gridSelectScreen.selectedCards.clear();
             AbstractDungeon.player.hand.refreshHandLayout();
-            isDone = true;
+            isDone = true; return;
         }
+
     }
 }

--- a/src/main/java/demoMod/icebreaker/patches/CardCrawlGamePatch.java
+++ b/src/main/java/demoMod/icebreaker/patches/CardCrawlGamePatch.java
@@ -6,6 +6,7 @@ import com.google.gson.reflect.TypeToken;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
+import demoMod.icebreaker.cards.lightlemon.AbstractLightLemonCard;
 
 import java.io.*;
 import java.util.List;
@@ -34,6 +35,15 @@ public class CardCrawlGamePatch {
                             index++;
                         }
                     }
+
+                    // MODIFIED BY AKDREAM10086
+                    for (AbstractCard card : p.masterDeck.group) {
+                        if (card instanceof AbstractLightLemonCard) {
+                            ((AbstractLightLemonCard) card).loadCardsToPreview();
+                        }
+                    }
+                    // load cardsToPreview after uuid is loaded so that it's correctly loaded
+
                 } catch (IOException e) {
                     e.printStackTrace();
                 }


### PR DESCRIPTION
修复一些bug
1. 羁绊卡在sl时要等到加载完原来的uuid再找myCardsToPreview 不然找不到
2. 还是修了一下之前提到的一些比较严重的bug (挥舞法杖没法多选羁绊,选牌界面一张不选导致卡死) SelectCardInCardGroupAction的问题

对羁绊的ui进行一些优化
1. 查看主牌组时，鼠标挪到某张牌上会高亮显示这张牌羁绊的几张牌
2. 战斗时鼠标挪到某张牌上会显示羁绊的牌(如果多张会循环显示)，并且这其中目前在抽牌堆里的牌(也就是能抽上来的牌)会发光显示
3. 有些牌升级后增加羁绊数目，选择新增羁绊牌时不再出现已经被此牌羁绊过的牌
