### PR TITLE
一些修改

### DIFF
--- a/src/main/java/demoMod/icebreaker/actions/DiscoverMagicCardAction.java
+++ b/src/main/java/demoMod/icebreaker/actions/DiscoverMagicCardAction.java
@@ -11,6 +11,7 @@ import demoMod.icebreaker.IceBreaker;
 import demoMod.icebreaker.enums.CardTagEnum;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import static com.megacrit.cardcrawl.dungeons.AbstractDungeon.*;
 import static com.megacrit.cardcrawl.dungeons.AbstractDungeon.cardRandomRng;
@@ -18,6 +19,10 @@ import static com.megacrit.cardcrawl.dungeons.AbstractDungeon.cardRandomRng;
 public class DiscoverMagicCardAction extends DiscoveryAction {
     // 从3张随机魔法牌中选择一张加入手牌，其本回合耗能为0
     // 遗物：魔法卷轴
+
+    public DiscoverMagicCardAction(AbstractCard.CardType type, int amount) {
+        super(type, amount);
+    }
 
     @SpirePatch(clz = DiscoveryAction.class, method = "generateCardChoices")
     public static class MagicCardPatch {

--- a/src/main/java/demoMod/icebreaker/cards/lightlemon/AbstractLightLemonCard.java
+++ b/src/main/java/demoMod/icebreaker/cards/lightlemon/AbstractLightLemonCard.java
@@ -35,6 +35,8 @@ public abstract class AbstractLightLemonCard extends CustomCard implements CardA
     public int fetterAmount = 1; // 要不还是public吧？
     private float previewTimer = 0.0F;
 
+    public boolean ConnectionOfMeteor = false;
+
     public AbstractLightLemonCard(String id, String name, String img, int cost, String rawDescription, CardType type, CardRarity rarity, CardTarget target) {
         super(id, name, img, cost, rawDescription, type, AbstractCardEnum.ICEBREAKER, rarity, target);
     }
@@ -119,7 +121,7 @@ public abstract class AbstractLightLemonCard extends CustomCard implements CardA
 
             // modified to simplify the code
             lightLemonCard.loadCardsToPreview();
-
+            lightLemonCard.ConnectionOfMeteor = this.ConnectionOfMeteor;
         }
         return card;
     }

--- a/src/main/java/demoMod/icebreaker/cards/lightlemon/AbstractLightLemonCard.java
+++ b/src/main/java/demoMod/icebreaker/cards/lightlemon/AbstractLightLemonCard.java
@@ -103,7 +103,8 @@ public abstract class AbstractLightLemonCard extends CustomCard implements CardA
     }
 
     private AbstractCard makeStatEquivalentCopyWithoutPreviewCard() { //防止两张牌互相羁绊时出现递归调用的情况
-        AbstractCard card = super.makeSameInstanceOf();
+        AbstractCard card = super.makeStatEquivalentCopy();
+        card.uuid = this.uuid;
         // 复制的uuid相同来触发"发光显示目前在抽牌堆中的牌的效果"
         if (card instanceof AbstractLightLemonCard) {
             AbstractLightLemonCard lightLemonCard = (AbstractLightLemonCard) card;

--- a/src/main/java/demoMod/icebreaker/relics/ConnectionOfMeteor.java
+++ b/src/main/java/demoMod/icebreaker/relics/ConnectionOfMeteor.java
@@ -10,6 +10,8 @@ import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import demoMod.icebreaker.IceBreaker;
 import demoMod.icebreaker.cards.lightlemon.AbstractLightLemonCard;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.function.Predicate;
 
@@ -20,7 +22,6 @@ public class ConnectionOfMeteor extends CustomRelic implements CustomBottleRelic
     public static final String ID = IceBreaker.makeID("ConnectionOfMeteor");
     private static final Texture IMG = new Texture(IceBreaker.getResourcePath("relics/ConnectionOfMeteor.png"));
     private static final Texture IMG_OUTLINE = new Texture(IceBreaker.getResourcePath("relics/ConnectionOfMeteor_outline.png"));
-
     private static AbstractCard card;
     public ConnectionOfMeteor() {
         super(ID, IMG, IMG_OUTLINE, RelicTier.COMMON, LandingSound.MAGICAL);
@@ -71,7 +72,9 @@ public class ConnectionOfMeteor extends CustomRelic implements CustomBottleRelic
         AbstractDungeon.getCurrRoom().phase = AbstractRoom.RoomPhase.INCOMPLETE;
         CardGroup group = new CardGroup(CardGroup.CardGroupType.UNSPECIFIED);
         for (AbstractCard c : player.masterDeck.group) {
-            if (c instanceof AbstractLightLemonCard && !((AbstractLightLemonCard) c).isFetter) {
+            if (c instanceof AbstractLightLemonCard &&
+                    !((AbstractLightLemonCard) c).isFetter &&
+                    !((AbstractLightLemonCard) c).ConnectionOfMeteor) {
                 group.addToBottom(c);
             }
         }
@@ -82,9 +85,10 @@ public class ConnectionOfMeteor extends CustomRelic implements CustomBottleRelic
         super.update();
         if (!cardSelected && !AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
             cardSelected = true;
-            AbstractCard card = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
-            if (card instanceof AbstractLightLemonCard) {
-                AbstractLightLemonCard card1 = (AbstractLightLemonCard)card;
+            AbstractCard c = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
+            if (c instanceof AbstractLightLemonCard) {
+                card = c;
+                AbstractLightLemonCard card1 = (AbstractLightLemonCard)c;
                 card1.ConnectionOfMeteor = true;
                 card1.isFetter = true; card1.fetterAmount = 1;
                 card1.onAddToMasterDeck();

--- a/src/main/java/demoMod/icebreaker/relics/ConnectionOfMeteor.java
+++ b/src/main/java/demoMod/icebreaker/relics/ConnectionOfMeteor.java
@@ -1,6 +1,8 @@
 package demoMod.icebreaker.relics;
 
+import basemod.abstracts.CustomBottleRelic;
 import basemod.abstracts.CustomRelic;
+import basemod.abstracts.CustomSavable;
 import com.badlogic.gdx.graphics.Texture;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.CardGroup;
@@ -9,13 +11,17 @@ import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import demoMod.icebreaker.IceBreaker;
 import demoMod.icebreaker.cards.lightlemon.AbstractLightLemonCard;
 
+import java.util.function.Predicate;
+
 import static com.megacrit.cardcrawl.dungeons.AbstractDungeon.player;
 
-public class ConnectionOfMeteor extends CustomRelic {
+// 使用basemod的CustomBottleRelic接口，这样在查看牌组时被这个遗物选择的牌右上角会有遗物标志
+public class ConnectionOfMeteor extends CustomRelic implements CustomBottleRelic, CustomSavable<Integer> {
     public static final String ID = IceBreaker.makeID("ConnectionOfMeteor");
     private static final Texture IMG = new Texture(IceBreaker.getResourcePath("relics/ConnectionOfMeteor.png"));
     private static final Texture IMG_OUTLINE = new Texture(IceBreaker.getResourcePath("relics/ConnectionOfMeteor_outline.png"));
 
+    private static AbstractCard card;
     public ConnectionOfMeteor() {
         super(ID, IMG, IMG_OUTLINE, RelicTier.COMMON, LandingSound.MAGICAL);
     }
@@ -25,6 +31,32 @@ public class ConnectionOfMeteor extends CustomRelic {
         return DESCRIPTIONS[0];
     }
 
+    @Override
+    public Predicate<AbstractCard> isOnCard() {
+        return c -> c instanceof AbstractLightLemonCard && ((AbstractLightLemonCard) c).ConnectionOfMeteor;
+    }
+
+    @Override
+    public Integer onSave() {
+        if (card != null) {
+            return AbstractDungeon.player.masterDeck.group.indexOf(card);
+        } else {
+            return -1;
+        }
+    }
+
+    @Override
+    public void onLoad(Integer cardIndex) {
+        if (cardIndex == null) {
+            return;
+        }
+        if (cardIndex >= 0 && cardIndex < AbstractDungeon.player.masterDeck.group.size()) {
+            card = AbstractDungeon.player.masterDeck.group.get(cardIndex);
+            if (card instanceof AbstractLightLemonCard) {
+                ((AbstractLightLemonCard) card).ConnectionOfMeteor = true;
+            }
+        }
+    }
 
     private boolean cardSelected = true;
 
@@ -53,6 +85,7 @@ public class ConnectionOfMeteor extends CustomRelic {
             AbstractCard card = AbstractDungeon.gridSelectScreen.selectedCards.get(0);
             if (card instanceof AbstractLightLemonCard) {
                 AbstractLightLemonCard card1 = (AbstractLightLemonCard)card;
+                card1.ConnectionOfMeteor = true;
                 card1.isFetter = true; card1.fetterAmount = 1;
                 card1.onAddToMasterDeck();
             }

--- a/src/main/java/demoMod/icebreaker/relics/MagicalScroll.java
+++ b/src/main/java/demoMod/icebreaker/relics/MagicalScroll.java
@@ -3,6 +3,7 @@ package demoMod.icebreaker.relics;
 import basemod.abstracts.CustomRelic;
 import com.badlogic.gdx.graphics.Texture;
 import com.megacrit.cardcrawl.actions.common.RelicAboveCreatureAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import demoMod.icebreaker.IceBreaker;
 import demoMod.icebreaker.actions.DiscoverMagicCardAction;
@@ -25,6 +26,10 @@ public class MagicalScroll extends CustomRelic {
     public void atBattleStart() {
         this.flash();
         this.addToBot(new RelicAboveCreatureAction(AbstractDungeon.player, this));
-        this.addToBot(new DiscoverMagicCardAction());
+        /*
+            矢野写的sb代码看是否传进去了type来判断有没有跳过按钮 ("发现"这张牌没有跳过，攻击/技能/能力药水有跳过)
+            我改写了获取随机牌的方法，所以随便传个type进去都行
+        */
+        this.addToBot(new DiscoverMagicCardAction(AbstractCard.CardType.SKILL, 1));
     }
 }


### PR DESCRIPTION
魔法卷轴添加跳过选项
在查看牌组时流星之绊选择的牌右上角会出现该遗物的图标
修复之前被我手贱改回去的无限递归调用羁绊bug