### PR TITLE
修复[追加触发]和[层积式冰墙]复制的牌不继承原来的"被羁绊"状态的问题

### DIFF
--- a/src/main/java/demoMod/icebreaker/cards/lightlemon/CascadeIceWall.java
+++ b/src/main/java/demoMod/icebreaker/cards/lightlemon/CascadeIceWall.java
@@ -62,7 +62,7 @@ public class CascadeIceWall extends AbstractLightLemonCard {
         if (p.hasPower(ExtraTurnPower.POWER_ID) && !this.exhaustOnUseOnce) {
             addToBot(new CascadeIceWallAction(p));
         } else if (!this.isInAutoplay) {
-            addToBot(new MakeTempCardInDiscardAction(makeStatEquivalentCopy(), 1));
+            addToBot(new MakeTempCardInDiscardAction(makeSameInstanceOf(), true));
         }
     }
 }

--- a/src/main/java/demoMod/icebreaker/cards/lightlemon/ExtraTrigger.java
+++ b/src/main/java/demoMod/icebreaker/cards/lightlemon/ExtraTrigger.java
@@ -4,6 +4,7 @@ import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.GameActionManager;
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.common.DiscardAction;
+import com.megacrit.cardcrawl.actions.common.ExhaustAction;
 import com.megacrit.cardcrawl.actions.common.ExhaustSpecificCardAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
@@ -52,9 +53,8 @@ public class ExtraTrigger extends AbstractLightLemonCard {
                     this.isDone = true;
                     return;
                 }
-
                 if (firstFrame) {
-                    AbstractDungeon.handCardSelectScreen.open(DiscardAction.TEXT[0], ExtraTrigger.this.magicNumber, true, true);
+                    AbstractDungeon.handCardSelectScreen.open(ExhaustAction.TEXT[0], ExtraTrigger.this.magicNumber, true, true);
                     AbstractDungeon.player.hand.applyPowers();
                     firstFrame = false;
                     return;

--- a/src/main/java/demoMod/icebreaker/powers/NextTurnPlayCardPower.java
+++ b/src/main/java/demoMod/icebreaker/powers/NextTurnPlayCardPower.java
@@ -41,9 +41,12 @@ public class NextTurnPlayCardPower extends AbstractPower {
     @Override
     public void atStartOfTurn() {
         this.flash();
-        AbstractCard c = card.makeStatEquivalentCopy();
+        AbstractCard c = card.makeSameInstanceOf();
         c.freeToPlayOnce = true;
-        this.addToBot(new MakeTempCardInHandAction(c, this.amount));
+        for (int i = 0; i < this.amount; i++) {
+            this.addToBot(new MakeTempCardInHandAction(c, true, true));
+        }
+
 
 //        for (int i=0;i<this.amount;i++) {
 //            AbstractMonster m = null;


### PR DESCRIPTION
A牌羁绊B牌，使用[追加触发]消耗B并且下回合加入B的复制，更改后A仍会羁绊B的复制

(将复制的uuid改为和本体相同)