### PR TITLE
Improved `Eng` translation & two bug fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ src/test/
 *.docx
 /src/main/resources/IceImages/cards/cardsToCut/
 /src/main/resources/IceImages/cards/cardsToReplace/
+pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,10 @@
 
     <groupId>demoMod</groupId>
     <artifactId>ice-breaker</artifactId>
-    <version>1.0</version>
+    <version>1.0.0</version>
+    <properties>
+    <steam.path>C:/Program Files (x86)/steam/steamapps</steam.path>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/src/main/java/demoMod/icebreaker/cards/lightlemon/BloodyPath.java
+++ b/src/main/java/demoMod/icebreaker/cards/lightlemon/BloodyPath.java
@@ -1,5 +1,6 @@
 package demoMod.icebreaker.cards.lightlemon;
 
+import com.evacipated.cardcrawl.mod.stslib.powers.interfaces.InvisiblePower;
 import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.actions.common.DamageAction;
 import com.megacrit.cardcrawl.actions.common.RemoveSpecificPowerAction;
@@ -48,8 +49,10 @@ public class BloodyPath extends AbstractLightLemonCard {
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
         for (AbstractPower power : p.powers) {
-            addToTop(new RemoveSpecificPowerAction(p, p, power));
-            addToBot(new DamageAction(m, new DamageInfo(p, this.damage, this.damageTypeForTurn), AbstractGameAction.AttackEffect.SLASH_HEAVY));
+            if(!(p instanceof InvisiblePower)) {
+                addToTop(new RemoveSpecificPowerAction(p, p, power));
+                addToBot(new DamageAction(m, new DamageInfo(p, this.damage, this.damageTypeForTurn), AbstractGameAction.AttackEffect.SLASH_HEAVY));
+            }
         }
     }
 }

--- a/src/main/java/demoMod/icebreaker/relics/CrystalOfRadiance.java
+++ b/src/main/java/demoMod/icebreaker/relics/CrystalOfRadiance.java
@@ -1,6 +1,7 @@
 package demoMod.icebreaker.relics;
 
 import basemod.abstracts.CustomRelic;
+import basemod.helpers.CardPowerTip;
 import com.badlogic.gdx.graphics.Texture;
 import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
 import com.megacrit.cardcrawl.actions.utility.UseCardAction;
@@ -20,6 +21,7 @@ public class CrystalOfRadiance extends CustomRelic {
 
     public CrystalOfRadiance() {
         super(ID, IMG, IMG_OUTLINE, RelicTier.RARE, LandingSound.SOLID);
+        tips.add(new CardPowerTip(new Spark()));
     }
 
     @Override

--- a/src/main/java/demoMod/icebreaker/relics/Letter.java
+++ b/src/main/java/demoMod/icebreaker/relics/Letter.java
@@ -15,7 +15,8 @@ public class Letter extends CustomRelic implements EnterOrExitExtraTurnSubscribe
     private static final Texture IMG_OUTLINE = new Texture(IceBreaker.getResourcePath("relics/Letter_outline.png"));
 
     public Letter() {
-        super(ID, IMG, IMG_OUTLINE, RelicTier.BOSS, LandingSound.FLAT);
+        super(ID, IMG, IMG_OUTLINE, RelicTier.BOSS, //Boss?
+                LandingSound.FLAT);
     }
 
     @Override
@@ -27,7 +28,7 @@ public class Letter extends CustomRelic implements EnterOrExitExtraTurnSubscribe
     public void onEnterExtraTurn() {
         this.flash();
         addToBot(new RelicAboveCreatureAction(AbstractDungeon.player, this));
-        addToBot(new DrawCardAction(1));
+        addToBot(new DrawCardAction(1)); //2?
         addToBot(new GainEnergyAction(1));
     }
 

--- a/src/main/resources/ModTheSpire.json
+++ b/src/main/resources/ModTheSpire.json
@@ -3,7 +3,7 @@
   "name": "[Zehhyo no Yusha] 绝冰的勇者",
   "author_list": ["Temple9", "akdream10086", "GM_Whitose", "很很很喜欢**的银墨", "10000volts"],
   "description": "",
-  "credits": "",
+  "credits": "SandTag (Eng Loc Work)",
   "version": "1.2.0",
   "sts_version": "03-07-2022",
   "mts_version": "3.24.0",

--- a/src/main/resources/localization/eng/IceBreaker-CardStrings.json
+++ b/src/main/resources/localization/eng/IceBreaker-CardStrings.json
@@ -31,21 +31,21 @@
   },
   "IceBreaker:FrostWind": {
     "NAME": "Frosty Wind",
-    "DESCRIPTION": "im:Magic. im:Ranged. im:Connect. NL Deal !D! damage, NL Apply !M! Weak. NL im:Respond : Gain !B! Block."
+    "DESCRIPTION": "im:Magic. im:Ranged. im:Connect. NL Deal !D! damage, NL apply !M! Weak. NL im:Respond : Gain !B! Block."
   },
   "IceBreaker:HeavySnow": {
     "NAME": "Snowflakes",
-    "DESCRIPTION": "im:Magic. im:Ranged. NL Deal !D! damage to ALL enemies. NL  Apply !M! Weak to ALL enemies. NL Whenever you im:Respond successfully, increase this card's damage by two this combat.",
-    "UPGRADE_DESCRIPTION": "im:Magic. im:Ranged. NL Deal !D! damage to ALL enemies. NL  Apply !M! Weak to ALL enemies. NL Whenever you im:Respond successfully, increase this card's damage by three this combat."
+    "DESCRIPTION": "im:Magic. im:Ranged. NL Deal !D! damage and apply !M! Weak to ALL enemies. NL When you im:Respond successfully, raise this cards damage by 2 this combat.",
+    "UPGRADE_DESCRIPTION": "im:Magic. im:Ranged. NL Deal !D! damage and apply !M! Weak to ALL enemies. NL When you im:Respond successfully, raise this cards damage by 3 this combat."
   },
   "IceBreaker:Flash": {
     "NAME": "Flash",
-    "DESCRIPTION": "im:Ranged. NL Deal !D! damage. NL If you have no [E] left , gain [E].",
-    "UPGRADE_DESCRIPTION": "im:Ranged. NL Deal !D! damage. NL If you have no [E] left , gain [E] [E]."
+    "DESCRIPTION": "im:Ranged. NL Deal !D! damage. NL If you have no [E] left, gain [E].",
+    "UPGRADE_DESCRIPTION": "im:Ranged. NL Deal !D! damage. NL If you have no [E] left, gain [E] [E]."
   },
   "IceBreaker:Thunder": {
     "NAME": "Thunder",
-    "DESCRIPTION": "im:Magic. im:Ranged. im:Connect. NL Deal !D! damage. NL Whenever you im:Respond successfully, put this card into your hand if it is in your draw pile."
+    "DESCRIPTION": "im:Magic. im:Ranged. im:Connect. NL Deal !D! damage. NL When you im:Respond successfully, put this card into your hand if it is in your draw pile."
   },
   "IceBreaker:AirCut": {
     "NAME": "Air Cut",
@@ -66,7 +66,7 @@
   },
   "IceBreaker:RedMoon": {
     "NAME": "Bloody Moon",
-    "DESCRIPTION": "im:Magic. im:Ranged. im:Connect. NL Deal !D! damage. NL Add !M! *Spark on the top of your draw pile. NL im:Respond : Apply !M! Vulnerable to a random enemy."
+    "DESCRIPTION": "im:Magic. im:Ranged. im:Connect. NL Deal !D! damage. NL Add !M! *Spark on-top of your draw pile. NL im:Respond : Apply !M! Vulnerable to a random enemy."
   },
   "IceBreaker:SoulTremor": {
     "NAME": "Soul Tremor",
@@ -75,12 +75,12 @@
   },
   "IceBreaker:GhostGlim": {
     "NAME": "Ghost Lantern",
-    "DESCRIPTION": "im:Magic. im:Ranged. NL This enemy lose !M! HP. NL Shuffle !IM2! *Spark into your draw pile."
+    "DESCRIPTION": "im:Magic. im:Ranged. NL Enemy loses !M! HP. NL Shuffle !IM2! *Spark into your draw pile."
   },
   "IceBreaker:SilverDoor": {
     "NAME": "Silver Gate",
-    "DESCRIPTION": "im:Magic. NL Gain !B! Block. NL Within this turn, you won't lose im:Resonance.",
-    "UPGRADE_DESCRIPTION": "im:Magic. NL Gain !B! Block. NL Within two turns, you won't lose im:Resonance."
+    "DESCRIPTION": "im:Magic. NL Gain !B! Block. NL This turn, you won't lose im:Resonance.",
+    "UPGRADE_DESCRIPTION": "im:Magic. NL Gain !B! Block. NL During the next two turns, you won't lose im:Resonance."
   },
   "IceBreaker:Blizzard": {
     "NAME": "暴风雪",
@@ -88,11 +88,11 @@
   },
   "IceBreaker:WheelOfHeat": {
     "NAME": "Flame Wheel",
-    "DESCRIPTION": "Whenever you play a *Spark , deal !M! damage to ALL enemies."
+    "DESCRIPTION": "Whenever you play a *Spark, deal !M! damage to ALL enemies."
   },
   "IceBreaker:Electrospark": {
     "NAME": "Chronoflame",
-    "DESCRIPTION": "Retain. NL Gain im:Chronostasis equal to *Spark you played this combat ( no more than 12 ).",
+    "DESCRIPTION": "Retain. NL Gain im:Chronostasis equal to *Spark you played this combat (Max: 12).",
     "EXTENDED_DESCRIPTION": [
       "(Gain !M! im:Chronostasis )"
     ]
@@ -100,7 +100,7 @@
   "IceBreaker:SeaOfLanterns": {
     "NAME": "Red and Silver",
     "DESCRIPTION": "im:Magic. im:Connect. NL Gain !B! Block. NL Shuffle !M! *Spark into your draw pile. NL im:Respond : Shuffle an additional *Spark.",
-    "UPGRADE_DESCRIPTION": "im:Magic. im:Connect. NL Gain !B! Block. NL Shuffle !M! *Spark into your draw pile. NL im:Respond : Shuffle an additional *火花+.",
+    "UPGRADE_DESCRIPTION": "im:Magic. im:Connect. NL Gain !B! Block. NL Shuffle !M! *Spark into your draw pile. NL im:Respond : Shuffle an additional *Spark+.",
     "EXTENDED_DESCRIPTION": [
       "Sea of Lantern"
     ]
@@ -111,7 +111,7 @@
   },
   "IceBreaker:Pyroblast": {
     "NAME": "Fire Burst",
-    "DESCRIPTION": "im:Magic. im:Ranged. NL Deal damage equal to 4 plus the number of *Spark you played this combat multiply !M! to ALL enemies.",
+    "DESCRIPTION": "im:Magic. im:Ranged. NL Deal !M! times the number of *Spark you played this combat plus 4, damage to ALL enemies.",
     "EXTENDED_DESCRIPTION": [
       "(Deal !D! damage)"
     ]
@@ -127,7 +127,7 @@
   },
   "IceBreaker:ManaAgitation": {
     "NAME": "Mana Agitation",
-    "DESCRIPTION": "im:Magic. NL Put !M! im:Magic into your hand (Draw pile is prior). NL Take damage equal to number of cards in your hand."
+    "DESCRIPTION": "im:Magic. NL Draw !M! im:Magic cards then take damage equal to number of cards in your hand."
   },
   "IceBreaker:Snap": {
     "NAME": "Snap",
@@ -135,11 +135,11 @@
   },
   "IceBreaker:HauntHell": {
     "NAME": "Ghost Hell",
-    "DESCRIPTION": "im:Magic. im:Ranged. NL Deal !D! damage to ALL enemies six times. NL Shuffle !M! *Spark into your draw pile."
+    "DESCRIPTION": "im:Magic. im:Ranged. NL Deal !D! damage to ALL enemies six times. NL Shuffle !M! *Sparks into your draw pile."
   },
   "IceBreaker:FreezeKing": {
     "NAME": "King Freezing!",
-    "DESCRIPTION": "im:Magic. im:Ranged. NL Deal !D! damage. NL Apply !M! Weak. NL Choose at most !M! cards from discard pile to shuffle into your draw pile.",
+    "DESCRIPTION": "im:Magic. im:Ranged. NL Deal !D! damage. NL Apply !M! Weak. NL Choose up to !M! cards from discard pile to shuffle into your draw pile.",
     "EXTENDED_DESCRIPTION": [
       "Styx"
     ]
@@ -150,13 +150,13 @@
   },
   "IceBreaker:FakeParley": {
     "NAME": "Chronochime",
-    "DESCRIPTION": "im:Connect. NL gain !M! im:Chronostasis. NL Outside im:Gap : Next im:Magic can be affected by im:Resonance. NL im:Gap : draw !M! cards.",
-    "UPGRADE_DESCRIPTION": "im:Connect 2. NL gain !M! im:Chronostasis. NL Outside im:Gap : Next two im:Magic  can be affected by im:Resonance. NL im:Gap : draw !M! cards."
+    "DESCRIPTION": "im:Connect. NL gain !M! im:Chronostasis. NL Outside im:Gap : Next im:Magic card can be affected by im:Resonance. NL im:Gap : draw !M! cards.",
+    "UPGRADE_DESCRIPTION": "im:Connect 2. NL gain !M! im:Chronostasis. NL Outside im:Gap : Next two im:Magic cards can be affected by im:Resonance. NL im:Gap : draw !M! cards."
   },
   "IceBreaker:Oracle": {
     "NAME": "Oracle",
     "DESCRIPTION": "im:Connect. Gain !B! Block. NL Choose !M! card to Retain for a turn.",
-    "UPGRADE_DESCRIPTION": "im:Connect 2. NL Gain !B! Block. NL Choose !M! card to Retain for a turn.",
+    "UPGRADE_DESCRIPTION": "im:Connect 2. NL Gain !B! Block. NL Choose !M! cards to Retain for a turn.",
     "EXTENDED_DESCRIPTION": [
       " retain"
     ]
@@ -168,16 +168,16 @@
   },
   "IceBreaker:EliminateDistractions": {
     "NAME": "Eliminate Distractions",
-    "DESCRIPTION": "Choose !M! cards from your draw pile and Exhaust them. Shuffle a *Dazed into your darw pile."
+    "DESCRIPTION": "Choose !M! cards from your draw pile and Exhaust them. Shuffle a *Dazed into your draw pile."
   },
   "IceBreaker:MagicExtraction": {
     "NAME": "Extract Mana",
-    "DESCRIPTION": "Remove at most !M! Weak on an enemy, gain that many [E]. NL Exhaust.",
-    "UPGRADE_DESCRIPTION": "Remove at most !M! Weak on an enemy, gain that many [E]."
+    "DESCRIPTION": "Remove up to !M! Weak on an enemy, gain equal [E]. NL Exhaust.",
+    "UPGRADE_DESCRIPTION": "Remove up to !M! Weak on an enemy, gain equal [E]."
   },
   "IceBreaker:OtherPartyOfMissing": {
     "NAME": "See You Otherside",
-    "DESCRIPTION": "Gain !B! Block. NL If you enter im:Chronogap or end your turn with this card is in hand, increase this card's Block by !M! in this combat.",
+    "DESCRIPTION": "Gain !B! Block. NL If you enter im:Chronogap or end your turn with this card in your hand, increase this card's Block by !M! this combat.",
     "EXTENDED_DESCRIPTION": [
       "……I miss you."
     ]
@@ -192,7 +192,7 @@
   },
   "IceBreaker:CascadeIceWall": {
     "NAME": "Cascaded Icy Wall",
-    "DESCRIPTION": "im:Magic. im:Connect. NL Gain !B! Block. NL Outside im:Gap: Add a copy of this card into your discard pile. NL  im:Gap : Play ALL copies in draw pile, hand and discard pile then Exhaust them.",
+    "DESCRIPTION": "im:Magic. im:Connect. NL Gain !B! Block. NL Outside im:Gap: Copy this into your discard pile. NL im:Gap : Play and Exhaust ALL copies in combat.",
     "EXTENDED_DESCRIPTION": [
       "Wishes at that Time"
     ]
@@ -219,7 +219,7 @@
   },
   "IceBreaker:TimeLetter": {
     "NAME": "Chronomunicate",
-    "DESCRIPTION": "im:Magic. im:Ranged. NL Deal !D! damage. NL If you have no less than two im:Chronostasis, consume three and deal !D! damage once more, at the start of your next turn, gain !M! im:Chronostasis."
+    "DESCRIPTION": "im:Magic. im:Ranged. NL Deal !D! damage. NL Pay 3 im:Chronostasis, to deal !D! damage again. NL next turn, gain !M! im:Chronostasis."
   },
   "IceBreaker:MaterialDecomposition": {
     "NAME": "Decompose Material",
@@ -236,13 +236,13 @@
   },
   "IceBreaker:HolyZone": {
     "NAME": "Holy Zone",
-    "DESCRIPTION": "Stun all enemies whose HP is less than half. Exhaust.",
-    "UPGRADE_DESCRIPTION": "Retain. NL Stun all enemies whose HP is less than half. Exhaust."
+    "DESCRIPTION": "Stun ALL enemies whose HP is less than 50%. Exhaust.",
+    "UPGRADE_DESCRIPTION": "Retain. NL Stun ALL enemies whose HP is less than 50%. Exhaust."
   },
   "IceBreaker:MemoriesFloodBack": {
     "NAME": "Frosted Star Fantasy",
-    "DESCRIPTION": "Exhaust your hand. NL Add copies of all cards you start this combat into your hand. NL This card will only appear at the bottom of your draw pile. Exhaust.",
-    "UPGRADE_DESCRIPTION": "Retain. NL Exhaust your hand. NL Add copies of all cards you start this combat into your hand. NL This card will only appear at the bottom of your draw pile. Exhaust."
+    "DESCRIPTION": "Exhaust your hand. NL Gain a copy of your opening hand. NL im:Unnate. Exhaust.",
+    "UPGRADE_DESCRIPTION": "Retain. NL Exhaust your hand. NL Gain a copy of your opening hand. NL im:Unnate. Exhaust."
   },
   "IceBreaker:TimeCreation": {
     "NAME": "Chronocreate",
@@ -250,7 +250,7 @@
   },
   "IceBreaker:Overgrow": {
     "NAME": "Tuft",
-    "DESCRIPTION": "im:Magic. im:Ranged. NL Deal !D! damage. NL Gain !B! Block. NL At the star of your next turn, add a copy with Exhaust into your hand."
+    "DESCRIPTION": "im:Magic. im:Ranged. NL Deal !D! damage. NL Gain !B! Block. NL At the start of your next turn, add a copy with Exhaust into your hand."
   },
   "IceBreaker:Negate": {
     "NAME": "Deny",
@@ -258,7 +258,7 @@
   },
   "IceBreaker:TimeShadow": {
     "NAME": "Chronoshadow",
-    "DESCRIPTION": "gain !M! im:Chronostasis. NL Scry !M!. NL Draw 1 card."
+    "DESCRIPTION": "Gain !M! im:Chronostasis. NL Scry !M!. NL Draw 1 card."
   },
   "IceBreaker:TimeLeap": {
     "NAME": "Chronoleap",
@@ -266,19 +266,19 @@
   },
   "IceBreaker:SpaceOfChaos": {
     "NAME": "Chaospace",
-    "DESCRIPTION": "im:Magic. NL Gain !M! Buffer. Exhaust. NL im:Gap : Gain an additional Buffer."
+    "DESCRIPTION": "im:Magic. NL Gain !M! Buffer. NL im:Gap : Gain an additional Buffer. NL Exhaust."
   },
   "IceBreaker:StarDust": {
     "NAME": "Star Dust",
-    "DESCRIPTION": "The first !M! time you im:Respond successfully within a turn, gain [E]."
+    "DESCRIPTION": "The first !M! time(s) you im:Respond successfully each turn, gain [E]."
   },
   "IceBreaker:DiffuseFuture": {
     "NAME": "Diffuse Future",
-    "DESCRIPTION": "Outside im:Gap : enter im:Chronogap. NL im:Gap : end your turn, gain an extra turn and enter im:Gap when it start. NL Exhaust."
+    "DESCRIPTION": "Outside im:Gap : enter im:Chronogap. NL im:Gap : end your turn, gain an extra turn and enter im:Gap. NL Exhaust."
   },
   "IceBreaker:InfinityFortress": {
     "NAME": "Infinity Fortress",
-    "DESCRIPTION": "Gain !M! Metallicize for each [E] you have now. NL Exhaust."
+    "DESCRIPTION": "Gain !M! times X Metallicize. NL Exhaust."
   },
   "IceBreaker:AscendersBane": {
     "NAME": "Ascender's Bane",
@@ -295,12 +295,12 @@
   },
   "IceBreaker:DemonDeLaplace": {
     "NAME": "Demon De Laplace",
-    "DESCRIPTION": "Ethereal. NL Whenever you play a card is created in combat, gain !M! im:Resonance.",
-    "UPGRADE_DESCRIPTION": "Whenever you play a card is created in combat, gain !M! im:Resonance."
+    "DESCRIPTION": "Ethereal. NL Whenever you play a card created in combat, gain !M! im:Resonance.",
+    "UPGRADE_DESCRIPTION": "Whenever you play a card created in combat, gain !M! im:Resonance."
   },
   "IceBreaker:DeepCalculate": {
     "NAME": "Deep Calculate",
-    "DESCRIPTION": "Whenever you play a im:Connect card, additionally trigger its im:Respond once."
+    "DESCRIPTION": "Whenever you play a im:Connect card, additionally trigger its im:Respond."
   },
   "IceBreaker:Chronover": {
     "NAME": "Chronover",
@@ -309,7 +309,7 @@
   },
   "IceBreaker:ExtraTrigger": {
     "NAME": "Extra Trigger",
-    "DESCRIPTION": "Exhaust up to !M! cards. NL At the start of your next turn, add their copies into your hand, they cost 0 before you play."
+    "DESCRIPTION": "Exhaust up to !M! cards. NL At the start of your next turn, add copies of them into your hand, they cost 0 that turn."
   },
   "IceBreaker:Detonate": {
     "NAME": "Detonate",
@@ -332,8 +332,8 @@
   },
   "IceBreaker:GhostFantasy": {
     "NAME": "Ghost Fantasy",
-    "DESCRIPTION": "Can only be played as the only card in your hand. NL Choose 1 of 3 random cards to add into your hand, repeat !M! times.",
-    "UPGRADE_DESCRIPTION": "Can only be played as the only card in your hand. NL Choose 1 of 3 random Upgraded cards to add into your hand, repeat !M! times. NL They cost 0 this turn.",
+    "DESCRIPTION": "Can only be played as the last card in your hand. NL Choose 1 of 3 random cards to add into your hand, repeat !M! times.",
+    "UPGRADE_DESCRIPTION": "Can only be played as the last card in your hand. NL Choose 1 of 3 random Upgraded cards to add into your hand, repeat !M! times. NL They cost 0 this turn.",
     "EXTENDED_DESCRIPTION": [
       "Past as a Dream",
       "Card in my hand must no more than 1!"
@@ -354,7 +354,7 @@
   },
   "IceBreaker:Inspire": {
     "NAME": "Inspire",
-    "DESCRIPTION": "im:Connect. NL Gain !B! Block. NL Your next im:Magic costs 0. NL im:Gap :Your next im:Magic is played twice.",
+    "DESCRIPTION": "im:Connect. NL Gain !B! Block. NL Your next im:Magic card costs 0. NL im:Gap :Your next im:Magic card is played twice.",
     "EXTENDED_DESCRIPTION": [
       "Hallucination"
     ]
@@ -372,26 +372,26 @@
   },
   "IceBreaker:NightOfFireworks": {
     "NAME": "Hanabi",
-    "DESCRIPTION": "At the start of your turn or when you enter im:Chronogap , shuffle !M! *Spark into your draw pile.",
-    "UPGRADE_DESCRIPTION": "At the start of your turn or when you enter im:Chronogap , shuffle !M! *Spark+ into your draw pile."
+    "DESCRIPTION": "At the start of your turn or when you enter im:Chronogap, shuffle !M! *Spark into your draw pile.",
+    "UPGRADE_DESCRIPTION": "At the start of your turn or when you enter im:Chronogap, shuffle !M! *Spark+ into your draw pile."
   },
   "IceBreaker:VitalLoop": {
     "NAME": "Vital Loop",
-    "DESCRIPTION": "After the start of your turn, put no more than !M! card from your discard pile to shuffle into draw pile.",
-    "UPGRADE_DESCRIPTION": "Innate. NL After the start of your turn, put no more than !M! card from your discard pile to shuffle into draw pile."
+    "DESCRIPTION": "At the start of your turn you may put !M! card from your discard pile ontop of the draw pile.",
+    "UPGRADE_DESCRIPTION": "Innate. NL At the start of your turn you may put !M! card from your discard pile ontop of the draw pile."
   },
   "IceBreaker:FantasyDream": {
     "NAME": "Fantasy Dream",
-    "DESCRIPTION": "When you play a card which is not Exhaust or Power , Exhaust it and im:Trigger once more."
+    "DESCRIPTION": "When you play a card which does not Exhaust or is Power , Exhaust it and im:Trigger once more."
   },
   "IceBreaker:HarshTemperament": {
     "NAME": "Harsh",
-    "DESCRIPTION": "Whenever you enter im:Chronogap , your next im:Magic with non 0 cost will played twice."
+    "DESCRIPTION": "Whenever you enter im:Chronogap , your next im:Magic card with non 0 cost will played twice."
   },
   "IceBreaker:AsterismForm": {
     "NAME": "Asterism Form",
-    "DESCRIPTION": "At the start of your turn or when you enter im:Chronogap , choose 1 of 15 random cards from ALL colors to play. NL Every card can be used only once for a single run.",
-    "UPGRADE_DESCRIPTION": "At the start of your turn or when you enter im:Chronogap , choose 1 of 15 random Upgraded cards from ALL colors to play. NL Every card can be used only once for a single run."
+    "DESCRIPTION": "At the start of your turn or when you enter im:Chronogap , choose 1 of 15 random cards from ALL colors to play. NL Every card can be selected once per run.",
+    "UPGRADE_DESCRIPTION": "At the start of your turn or when you enter im:Chronogap , choose 1 of 15 random Upgraded cards from ALL colors to play. NL Every card can be selected once per run."
   },
   "IceBreaker:YesterdayOnceMore": {
     "NAME": "Yesterday Once More",

--- a/src/main/resources/localization/eng/IceBreaker-CharacterStrings.json
+++ b/src/main/resources/localization/eng/IceBreaker-CharacterStrings.json
@@ -4,7 +4,7 @@
       "Zehhyo no Yusha"
     ],
     "TEXT": [
-      "The Warrior who come to the spire for finding his relative. NL He is a magical expert, and able to manipulate time.",
+      "The Warrior who came to the spire looking for his relative. NL He is a magical expert, and able to manipulate time.",
       "You raise your #bstaff , operate your #pmana , #g~Face~ #g~that~ #g~you~ #g~miss~ come to your mind.",
       ""
     ],

--- a/src/main/resources/localization/eng/IceBreaker-EventStrings.json
+++ b/src/main/resources/localization/eng/IceBreaker-EventStrings.json
@@ -4,8 +4,8 @@
     "DESCRIPTIONS": [
       "While walking and traversing through the chaos of the Spire, your thoughts suddenly begin to feel very... #p~ real...~ NL NL Imaginings of #rmonsters and #yriches begin to manifest themselves into reality. NL The sensation is quickly fleeting. What do you do?",
       "Can it really be this easy?",
-      "Everything makes sense now. NL Memories of Ancient, Face of Relative, #yNeow in the bottom of the spire. NL NL The infinite spire contains all possibilities. NL As climbing, climbing…… NL NL Overcome any impediment, and climb forever……",
-      "You don't lack of money, maybe you will be laughed as an avaricious Warrior.",
+      "Everything makes sense now. NL Memories of Ancients, Faces of Relatives, #yNeow in the bottom of the spire. NL NL The seemingly infinite spire contains all possibilities. NL As climbing, climbing…… NL NL Overcome any impediment, and climb forever……",
+      "You don't lack money, maybe you will be mocked as an avaricious warrior.",
       "Facing such a sensation, you decide to bring your friends back to #g~life~ again. NL NL #pMemories of the pass, #bTime you shared with them. Every thing is displayed in front of you. NL #y~So~ #y~warm,~ #y~so~ #y~smooth,~ you hug your friend who can only be seen in your #bimagination . NL Tears drop down. NL NL #rWhat #rif #ryou #rprotect #rthem #rwell…… "
     ],
     "OPTIONS": [
@@ -21,9 +21,9 @@
     "NAME": "The Cleric",
     "DESCRIPTIONS": [
       "A strange blue humanoid with a golden helm(?) approaches you with a huge smile. NL When he saw your face, he began to speak to you @“Hello,@ @I'm@ #b@Cleric！@ @May@ @I@ @help@ @you?！@ ”",
-      "A warm #yGold #yLight envelops your body and dissipates. NL @“I@ @wish@ @you@ @a@ @happy@ @day,@ @Mr.Warrior!”@ Cleric says with smile,you notice his eras are trembling with joy. NL “Thanks.”After your simple response,you hit your ~road~ again.",
-      "A cold #bBlue #bFire envelops your body and dissipates. NL @“I@ @wish@ @you@ @a@ @happy@ @day,@ @Mr.Warrior!”@ Cleric says with smile,you notice his eras are trembling with joy. NL “Thanks.”After your simple response,you hit your ~road~ again.",
-      "ou don't trust this #b“Cleric” , so you leave."
+      "A warm #yGold #yLight envelops your body and dissipates. NL @“I@ @wish@ @you@ @a@ @happy@ @day,@ @Warrior!”@ Cleric says with smile, you notice his ears are twitching with joy. NL “Thanks.” After your simple response,you hit your ~road~ again.",
+      "A cold #bBlue #bFire envelops your body and dissipates. NL @“I@ @wish@ @you@ @a@ @happy@ @day,@ @Warrior!”@ Cleric says with smile, you notice his ears are twitching with joy. NL “Thanks.” After your simple response,you hit your ~road~ again.",
+      "You don't trust this #b“Cleric” , so you leave."
     ],
     "OPTIONS": [
       "[Heal] #gHeal #g",
@@ -38,7 +38,7 @@
     "DESCRIPTIONS": [
       "As you come to a dead-end and begin to turn around, walls @slam@ @down@ from the ceiling, @trapping@ @you!@ NL NL Three faces materialize from the walls and speak. NL #b“Forget #bwhat #byou #bknow, #band #bI'll #blet #byou #bgo.” NL #p“I #prequire #pchange #pto #psee #pa #pnew #pspace.” NL #y“If #yyou #ywant #yto #ypass #yme, #ythen #yyou #ymust #ygrow.”",
       "Satisfied, the walls in front of you merge back into the ceiling, leaving a path forward.",
-      "You use your magic to analise their power and absorb their power. NL At the same time, countless memories #b~flood~ #b~into~ #b~your~ #b~mind~ , you get a #r@Thumping@ #r@Headache@ , soon you fall down and lose sense. NL  NL When you wake up, the Living Wall had disappeared, left a path forward."
+      "You use your magic to inhibit and absorb their power. NL At the same time, countless memories #b~flood~ #b~into~ #b~your~ #b~mind~ , you get a #r@Thumping@ #r@Headache@ , soon you fall down and lose sense. NL NL When you wake up, the Living Wall had disappeared and left a path forward."
     ],
     "OPTIONS": [
       "[Forget] #gRemove #ga #gcard #gfrom #gyour #gdeck.",
@@ -49,14 +49,14 @@
       "Transform a card in your deck.",
       "Upgrade a card in your deck.",
       "[Leave]",
-      "[Locked] Need： Unupgraded card."
+      "[Locked] Need：Unupgraded card."
     ]
   },
   "IceBreaker:Scrap Ooze": {
     "NAME": "Scrap Ooze",
     "DESCRIPTIONS": [
       "As you walk into the room you hear a ~gurgling~ and the @grinding@ of metals. Before you is a slime-like creature that ate too much scrap for its own good. From the center of the creature you see glints of strange light, perhaps something magical? ",
-      "ou launch magic fire to drive the slime away. NL However, it #r@jumps@ #r@on@ #r@you@ as soon as it feels your flame!",
+      "You launch fire magic to drive the slime away. NL However, it #r@jumps@ #r@on@ #r@you@ as soon as it feels your flame!",
       "You decide to leave the area. NL The slime pays no attention, content with its meal."
     ],
     "OPTIONS": [
@@ -68,10 +68,10 @@
   "IceBreaker:Beggar": {
     "NAME": "Beggar",
     "DESCRIPTIONS": [
-      "An old beggar cloaked in fur reaches his hands out towards you as you pass.“Spare some coin, Mr.Warrior?”",
-      "“I know you are #bCleric.”You say with laughter. NL NL The beggar takes off its cloak to reveal that he is Cleric! NL “You are worthy of the Warrior, see through me without difficulty!” NL He holds a #bblue #bbright #bfire on his hand. NL NL “Would you like my assistant?”He says with respect.",
-      "You declining his kindness.Cleric wears his cloak,while you leave the place.",
-      "“Mr.Warrior, I wish you happy.” Cleric smiles.You wave your hand and say goodbye,then you continue to explore the spire."
+      "An old beggar cloaked in fur reaches his hands out towards you as you pass.“Spare some coin, Warrior?”",
+      "“I know you are #bCleric.”You say with laughter. NL NL The beggar takes off its cloak to reveal that he is Cleric! NL “You are a worthy warrior, to see through me without difficulty!” NL He holds a #bblue #bbright #bfire on his hand. NL NL “Would you like my assistance?” He says with respect.",
+      "You declining his kindness. Cleric wears his cloak, while you leave the place.",
+      "“Warrior, I wish you happy.” Cleric smiles.You wave your hand and say goodbye, then you continue to explore the spire."
     ],
     "OPTIONS": [
       "[Purify] #gRemove #ga #gcard #gfrom #gyour #gdeck.",
@@ -85,9 +85,9 @@
   "IceBreaker:Drug Dealer": {
     "NAME": "Drug Dealer",
     "DESCRIPTIONS": [
-      "A man with an eyepatch and a devilish grin strides up to you. NL “Hey there, Mr.Warrior. Interested in advancing science? I can make you stronger than any training or blessing. You're gonna need it if you're one of those heroes with a death wish.” NL ”Whad'ya say?” ",
+      "A man with an eyepatch and a devilish grin strides up to you. NL “Hey there, Warrior. Interested in advancing science? I can make you stronger than any training or blessing. You're gonna need it if you're one of those heroes with a death wish.” NL ”Whad'ya say?” ",
       "~“Wonderful.”~ NL You drink a little bottle of #b~blue~ #b~agentia~ ,then you get a #r@violent@ #r@stomachache.@  NL But the pain disappears soon. and you feel your consideration become #b~simpler~ .",
-      "~“Superb.”~ NL The man inject you with three unknown substances and pulls out a notepad. Aa you begin to feel light-headed, he stars to frantically write down notes. NL Losing track of time completely, by the time you regain your senses, the shady character has disappeared.",
+      "~“Superb.”~ NL The man injects you with three unknown substances and pulls out a notepad. As you begin to feel light-headed, he starts to frantically write down notes. NL Losing track of time completely, by the time you regain your senses, the shady character has disappeared.",
       "You do believe science, but the man is so doubtful that you leave quickly."
     ],
     "OPTIONS": [
@@ -107,7 +107,7 @@
       "In front of you sits an altar to a forgotten god. NL Atop the altar sits an ornate female statue with arms outstretched. NL She calls out to you, demanding sacrifice.",
       "As you gently set the idol onto the altar a #bcold #bwind swirls throughout the room. NL The arms of the statue begin to discolor and crumble. Your #yGolden #yIdol begins to dull in color and begins bleeding from its eyes. NL The bleeding never ceases.",
       "You stand on the altar and cut your wrists. NL As the #rblood spills out in sacrifice, the arms of the statue reach out and close around your eyes. NL Everything goes #p~dark.~ NL You wake up a short time later feeling a new potential surging through you.\n",
-      "You begin to smash the statue violently. NL With your hitting, #p~Fog~ and #p@Wailing@ surround you…… NL ~……~ NL ~…………~ NL You finally break the statue. NL NL “So there really is a god using #p~Curse~ to threaten people for sacrifice…… ” You Leave the room with sigh, continue to climb the spire."
+      "You begin to smash the statue violently. NL With your hitting, #p~Fog~ and #p@Wailing@ surround you…… NL ~……~ NL ~…………~ NL You finally break the statue. NL NL “So there really is a god using #p~Curses~ to threaten people for sacrifice…… ” You Leave the room with sigh, continue to climb the spire."
     ],
     "OPTIONS": [
       "[Offer] #rLose #rGolden #rIdol, #gobtain #ga #gspecial #gRelic.",
@@ -126,12 +126,12 @@
       "Navigating an unlit street, you come across several hooded figures in the midst of some dark ritual. As you approach, they turn to you in eerie unison. The tallest among them bares fanged teeth and extends a long, pale hand towards you. NL ~“Join~ ~us~ ~brother,~ ~and~ ~feel~ ~the~ ~warmth~ ~of~ ~the~ ~Spire.”~",
       "Navigating an unlit street, you come across several hooded figures in the midst of some dark ritual. As you approach, they turn to you in eerie unison. The tallest among them bares fanged teeth and extends a long, pale hand towards you. NL ~“Join~ ~us~ ~sister,~ ~and~ ~feel~ ~the~ ~warmth~ ~of~ ~the~ ~Spire.”~",
       "The tall figure grabs your arm, pulls you forward, and sinks his fangs into your neck. You feel a #p~dark~ #p~force~ pour into your neck and course through your body. NL NL ~……",
-      "……~ NL NL You wake up some time later, alone…… NL “As expected, it doesn't work…” You touch the bite #rwound on your neck, smile with self-mockery. You have already anticipated the result. NL After all, #p~Demon~  can't assimilate you, let alone #rVampires ?",
+      "……~ NL NL You wake up some time later, alone…… NL “As expected, it doesn't work…” You touch the bite #rwound on your neck, smile with arrogance. You have already anticipated the result. NL After all, a #p~Demon~ can't assimilate you, let alone #rVampires ?",
       "You step back and raise your Staff in defiance. NL The tall figure sighs. “Well, well.” NL The entire group of hooded figures morph into a thick black fog that flows away from you. NL You are alone once more.",
       "The pale figures gasp as you take out the #rBlood #rVial. NL “ ~The~ ~master's~ ~blood...~ ~the~ ~master's~ ~blood!~ @THE@ @MASTER'S@ @BLOOD!@ ” NL They all chant fervently as the tall one bows before you. “Drink from His blood, and become one with #b~Him~ .” NL The chant growing louder, you consume the contents of the vial. Your vision immediately ~warps~ and fades to #pdarkness. NL NL ~……",
-      "……~ NL NL You wake up some time later, alone…… NL “As expected, it doesn't work…” You lick your lips, smile with self-mockery. You have already anticipated the result. NL After all, #p~Demon~  can't assimilate you, let alone #rVampires ?",
+      "……~ NL NL You wake up some time later, alone…… NL “As expected, it doesn't work…” You lick your lips, smile with arrogance. You have already anticipated the result. NL After all, a #p~Demon~ can't assimilate you, let alone #rVampires ?",
       "Navigating an unlit street, you come across several hooded figures in the midst of some dark ritual. As you approach, they turn to you in eerie unison. The tallest among them bares fanged teeth and extends a long, pale hand towards you. NL ~“Join~ ~us~ ~the~ ~broken~ ~one,~ ~and~ ~feel~ ~the~ ~warmth~ ~of~ ~the~ ~Spire.”~",
-      "Navigating an unlit street, you come across several hooded figures in the midst of some dark ritual. As you approach, they turn to you in eerie unison. The tallest among them bares fanged teeth and extends a long, pale hand towards you. NL ~“Join~ ~us~ ~Mr.Warrior,~ ~and~ ~feel~ ~the~ ~warmth~ ~of~ ~the~ ~Spire.”~"
+      "Navigating an unlit street, you come across several hooded figures in the midst of some dark ritual. As you approach, they turn to you in eerie unison. The tallest among them bares fanged teeth and extends a long, pale hand towards you. NL ~“Join~ ~us~ ~Warrior,~ ~and~ ~feel~ ~the~ ~warmth~ ~of~ ~the~ ~Spire.”~"
     ],
     "OPTIONS": [
       "[Accept] #gRemove #gTwo #gAttacks #gfrom #gyour #gdeck. #rLose #r",
@@ -153,7 +153,7 @@
       "#g~TRIUMPH..~ NL NL The remains of a #p~ghostly~ #p~creature~ sink slowly into the mud before you, barely visible in the moonlight. NL You have proven yourself amongst your sisters. NL NL Standing victoriously, you wait in silence as the others ceremoniously place #ythe #ycreature's #yskull atop your head. The ritual has concluded. NL NL You head towards the Spire...",
       "#b~CONFUSION..~ NL NL #y[OBJECTIVE] #gBALANCE must be  #gENFORCED NL #y[DEFINE] #gBALANCE NL #y[ERROR] #gBALANCE #gNOT #gFOUND NL #y[DEFINE] #gBALANCE NL #y[ERROR] #gBALANCE #gNOT #gFOUND NL #y[WARNING] #rLarge #robject #rapproaching NL NL ~“I...~ ~..am~ ~....Neow...”~",
       "#p~SERENITY..~ NL NL Two primitive creatures fight over a carcass on the side of the road. You observe, devoid of emotion. NL #yWatch. #yRemember. #yLive. This is the Watcher's mission. NL NL Recently, one of your peers had stopped reporting on their assignment: a Spire of unknown origin. NL NL As the fight ends, you continue onward, unfazed by the bloody scene that took place.",
-      "#y~GAZE.~ NL NL The #yMoon was bright with few #bStar, silver light #g~covered~ #g~the~ #g~ground~ . NL In front of you stands a #bTall #bFigure , look at you eyes to eyes, with a #p~mild~ #p~eyesight~ . NL  #b“Just #brun #bafter #byour #blight, #bmy #blittle #bbrother. #bI #bwill #balways #bprotect #byou.” NL NL That's the reason why you step into the spire: to find the person who made such a promise to you."
+      "#y~GAZE.~ NL NL The #yMoon was bright with few #bStars, silver light #g~covered~ #g~the~ #g~ground~ . NL In front of you stands a #bTall #bFigure , look at you eyes to eyes, with a #p~mild~ #p~eyesight~ . NL  #b“Just #brun #bafter #byour #blight, #bmy #blittle #bbrother. #bI #bwill #balways #bprotect #byou.” NL NL That's the reason why you stepped into the spire: to find the person who made such a promise to you."
     ],
     "OPTIONS": [
       "[Recall] #gAdd #g1 #gColorless #gcard #ginto #gyour #gdeck.",
@@ -183,7 +183,7 @@
       "“Oooh, a free #gHeal for you!”",
       "“Looks like you won a #pCurse! NL That's not good. NL Oh well! Better luck next time!” NL Well, willing to gamble and accepting defeat.",
       "“Ohh, the power of #r~Darkness...~ NL Choose a card to remove from your deck!”",
-      "“Ur oh! NL You lose!” NL You spot him readying a shiv...",
+      "“Uh oh! NL You lose!” NL You spot him readying a shiv...",
       "Well, willing to gamble and accepting defeat. NL After all you're the Warrior, he just scratches your arm once and collect a little bottle of your blood. NL NL “The price has been paid!!” With that both the gremlin and its wheel disappear in a puff of smoke. NL You treat your wound soon and climb to the further.",
       "Gremlin looks at you with appointment, you ignore him and leave the area."
     ],

--- a/src/main/resources/localization/eng/IceBreaker-KeywordStrings.json
+++ b/src/main/resources/localization/eng/IceBreaker-KeywordStrings.json
@@ -5,7 +5,7 @@
       "共鸣"
     ],
     "PROPER_NAME": "Resonance",
-    "DESCRIPTION": "When you are in #yChronogap, #yResonance adds additional numerical value to #yMagics. NL After it works, reduced by #b1."
+    "DESCRIPTION": "When you are in #yChronogap, #yResonance adds additional numerical value to #yMagic cards. NL Each use, reduces it by #b1 [REMOVE_SPACE]."
   },
   {
     "NAMES": [
@@ -13,7 +13,7 @@
       "远程"
     ],
     "PROPER_NAME": "Ranged",
-    "DESCRIPTION": "Ignore #yThorn and #yFlight."
+    "DESCRIPTION": "Ignore #yThorns and #yFlight [REMOVE_SPACE]."
   },
   {
     "NAMES": [
@@ -21,7 +21,7 @@
       "魔法"
     ],
     "PROPER_NAME": "Magic",
-    "DESCRIPTION": "#yMagics is not affected by most of buffs on #yyourself."
+    "DESCRIPTION": "#yMagic cards are not affected by most buffs on #yyourself."
   },
   {
     "NAMES": [
@@ -61,7 +61,7 @@
       "羁绊"
     ],
     "PROPER_NAME": "Connect",
-    "DESCRIPTION": "Upon pickup, choose a card in your deck to be its target. NL Whenever you play this card while the target is in your draw pile, put it into your hand."
+    "DESCRIPTION": "Upon pickup, choose a card in your deck to add as a target. NL Whenever you play this card while targets are in your draw pile, put them into your hand."
   },
   {
     "NAMES": [
@@ -69,7 +69,7 @@
       "回应"
     ],
     "PROPER_NAME": "Respond",
-    "DESCRIPTION": "If a card is putted into your hand as a #yConnect target, or put its #yConnect target into your hand, it is regarded as #yRespond successfully."
+    "DESCRIPTION": "If a card is put into your hand as a #yConnect target, or put its #yConnect card into your hand, both cards activate their #yRespond effects successfully."
   },
   {
     "NAMES": [
@@ -77,7 +77,7 @@
       "时间停滞"
     ],
     "PROPER_NAME": "Chronostasis",
-    "DESCRIPTION": "When you obtain no less than #b12 #yChronostasis , lose #b12 #yChronostasis , enter #yChronogap."
+    "DESCRIPTION": "When you obtain #b12 #yChronostasis [REMOVE_SPACE], enter #yChronogap."
   },
   {
     "NAMES": [
@@ -87,6 +87,14 @@
       "gap"
     ],
     "PROPER_NAME": "Chronogap",
-    "DESCRIPTION": "Upon entering #yChronogap , gain [E] [E] . NL Playing a card in the #yGap will not trigger buffs about playing cards on enemies. NL Exit at the end of your turn.( You can enter another #yGap when you're in the #yGap)"
+    "DESCRIPTION": "Upon entering this stance, gain [E] [REMOVE_SPACE][E] [REMOVE_SPACE]. NL Playing a card in this stance will not count towards enemy buffs. NL Exit this stance at the end of your turn. (Entering this stance multiple times in one turn still grants energy.)"
+  },
+  {
+    "PROPER_NAME": "Unnate",
+    "NAMES": [
+      "Unnate",
+      "unnate"
+    ],
+    "DESCRIPTION": "Starts each combat at the bottom of your draw pile."
   }
 ]

--- a/src/main/resources/localization/eng/IceBreaker-PotionStrings.json
+++ b/src/main/resources/localization/eng/IceBreaker-PotionStrings.json
@@ -3,7 +3,7 @@
     "NAME": "Bottled Inspiration",
     "DESCRIPTIONS": [
       "Choose #b1 of #b3 random #yMagic cards to add to your hand, it cost #b0 this turn.",
-      "Choose #b1 of #b3 random #yMagic cards to add to your hand twice, it cost #b0 this turn."
+      "Choose #b1 of #b3 random #yMagic cards to add to your hand twice, they cost #b0 this turn."
     ]
   },
   "IceBreaker:BottledLight": {

--- a/src/main/resources/localization/eng/IceBreaker-PowerStrings.json
+++ b/src/main/resources/localization/eng/IceBreaker-PowerStrings.json
@@ -14,19 +14,19 @@
   "IceBreaker:ExtraTurnPower": {
     "NAME": "Chronogap",
     "DESCRIPTIONS": [
-      "When you enter #yChronogap , gain [E] [E] . NL Playing a card in the #Gap will not trigger buffs about playing cards on enemies."
+      "When you enter #yChronogap , gain [E] [REMOVE_SPACE][E] [REMOVE_SPACE]. NL Playing a card in this stance will not trigger enemy buffs."
     ]
   },
   "IceBreaker:ResonancePower": {
     "NAME": "Resonance",
     "DESCRIPTIONS": [
-      "When you are in #yChronogap, #yResonance adds additional numerical value to #yMagics by #b%d. NL After it works, you lose #b1 #yResonance."
+      "When you are in #yChronogap [REMOVE_SPACE], #yResonance adds additional numerical value to #yMagics by #b%d. NL Each use, reduces it by #b1 [REMOVE_SPACE]."
     ]
   },
   "IceBreaker:DoubleBlockPower": {
     "NAME": "Double Block",
     "DESCRIPTIONS": [
-      "Next #b%d times when you gain #yBlock , #bdouble it."
+      "Next #b%d times when you gain #yBlock [REMOVE_SPACE], #bdouble it."
     ]
   },
   "IceBreaker:SilverDoorPower": {
@@ -68,32 +68,32 @@
   "IceBreaker:StarDustPower": {
     "NAME": "Star Dust",
     "DESCRIPTIONS": [
-      "The first #b%d time you #yConnect Respond successfully within a turn, gain [E] ."
+      "The first #b%d time you #yConnect Respond successfully each turn, gain [E] [REMOVE_SPACE]."
     ]
   },
   "IceBreaker:NiflheimrPower": {
     "NAME": "Niflheimr",
     "DESCRIPTIONS": [
-      "At the start of your turn, ALL enemies lose #b%d Strength. ",
-      "At the start of your turn or whenever you enter #yChronogap , ALL enemies lose #b%d Strength."
+      "At the start of your turn, ALL enemies lose #b%d #yStrength [REMOVE_SPACE].",
+      "At the start of your turn or whenever you enter #yChronogap , ALL enemies lose #b%d #yStrength [REMOVE_SPACE]."
     ]
   },
   "IceBreaker:WheelOfHeatPower": {
     "NAME": "Flame Wheel",
     "DESCRIPTIONS": [
-      "Whenever you play a #ySpark , deal #b%d damage to ALL enemies."
+      "Whenever you play a #ySpark [REMOVE_SPACE], deal #b%d damage to ALL enemies."
     ]
   },
   "IceBreaker:DemonDeLaplacePower": {
     "NAME": "Demon De Laplace",
     "DESCRIPTIONS": [
-      "Whenever you play a card is created in combat, gain #b%d #yResonance."
+      "Whenever you play a card that was created in combat, gain #b%d #yResonance [REMOVE_SPACE]."
     ]
   },
   "IceBreaker:ChronoChimePower": {
     "NAME": "Chronochime",
     "DESCRIPTIONS": [
-      "Your next #b%d #yMagic can be affected by #yResonance outside #yChronogap."
+      "Your next #b%d #yMagic card can be affected by #yResonance outside #yChronogap [REMOVE_SPACE]."
     ]
   },
   "IceBreaker:DeepCalculatePower": {
@@ -123,7 +123,7 @@
   "IceBreaker:FreeMagicPower": {
     "NAME": "Free Magic",
     "DESCRIPTIONS": [
-      "Your next #b%d #yMagic costs #b0. NL #yGap : Play it twice."
+      "Your next #b%d #yMagic card costs #b0. NL #yGap : Play it twice."
     ]
   },
   "IceBreaker:MagicalFloodPower": {
@@ -141,33 +141,33 @@
   "IceBreaker:NightOfFireworksPower": {
     "NAME": "Hanabi",
     "DESCRIPTIONS": [
-      "At the start of your turn or when you enter #yChronogap , shuffle #b%d #ySpark into your draw pile.",
-      "At the start of your turn or when you enter #yChronogap , shuffle #b%d #ySpark+ into your draw pile."
+      "At the start of your turn or when you enter #yChronogap [REMOVE_SPACE], shuffle #b%d #ySpark into your draw pile.",
+      "At the start of your turn or when you enter #yChronogap [REMOVE_SPACE], shuffle #b%d #ySpark+ into your draw pile."
     ]
   },
   "IceBreaker:VitalLoopPower": {
     "NAME": "Vital Loop",
     "DESCRIPTIONS": [
-      "After the start of your turn, put no more than #b%d card from your discard pile to shuffle into draw pile."
+      "At the start of your turn, you may put up to #b%d card(s) from your discard pile on-top of your draw pile."
     ]
   },
   "IceBreaker:FantasyDreamPower": {
     "NAME": "Fantasy Dream",
     "DESCRIPTIONS": [
-      "When you play a card which is not #yExhaust or #yPower , #yExhaust it and #yTrigger #b%d times more."
+      "When you play a card which does not #yExhaust or is a  #yPower [REMOVE_SPACE], #yExhaust it and #yTrigger it #b%d times more."
     ]
   },
   "IceBreaker:HarshTemperamentPower": {
     "NAME": "Harsh",
     "DESCRIPTIONS": [
-      "Whenever you enter #yChronogap , your next #yMagic with non #b0 cost will played #b%d times."
+      "Whenever you enter #yChronogap [REMOVE_SPACE], your next #yMagic card with non #b0 cost will played #b%d times."
     ]
   },
   "IceBreaker:AsterismFormPower": {
     "NAME": "Asterism Form",
     "DESCRIPTIONS": [
-      "At the start of your turn or when you enter #yChronogap , choose #b1 of #b15 random cards from ALL colors to play, repeat #b%d times.",
-      "At the start of your turn or when you enter #yChronogap , choose #b1 of #b15 random Upgraded cards from ALL colors to play, repeat #b%d times."
+      "At the start of your turn or when you enter #yChronogap [REMOVE_SPACE], choose #b1 of #b15 random cards from ALL colors to play, repeat #b%d times.",
+      "At the start of your turn or when you enter #yChronogap [REMOVE_SPACE], choose #b1 of #b15 random Upgraded cards from ALL colors to play, repeat #b%d times."
     ]
   },
   "IceBreaker:YesterdayOnceMorePower": {
@@ -210,7 +210,7 @@
   "IceBreaker:DisobeyPower": {
     "NAME": "Disobey",
     "DESCRIPTIONS": [
-      "#yConnect can success when #yConnect target is in discard pile."
+      "#yConnect can be successful when #yConnect target card is in discard pile."
     ]
   },
   "IceBreaker:TsukishiRitsuPower": {

--- a/src/main/resources/localization/eng/IceBreaker-RelicStrings.json
+++ b/src/main/resources/localization/eng/IceBreaker-RelicStrings.json
@@ -3,35 +3,35 @@
     "NAME": "Blizzard Staff",
     "FLAVOR": "It is made of solid-state icy magical power completely.",
     "DESCRIPTIONS": [
-      "The first time of the combat when you gain #yBlock , double it. NL Start each combat with #b4 #yim:Chronostasis."
+      "Start each combat with #b4 #yim:Chronostasis. NL The first time you gain #yBlock each combat, double it."
     ]
   },
   "IceBreaker:StaffMidwinter": {
     "NAME": "Midwinter Staff",
-    "FLAVOR": "It was injected divine power by the God of Time,and became a unique wand -- present from Chronos.",
+    "FLAVOR": "It was injected with divine power by the God of Time and became a unique wand. \n - Present from Chronos.",
     "DESCRIPTIONS": [
-      "Replaces #yBlizzard #yStaff. The first time of the combat when you gain #yBlock , double it. NL At the start of your turn, gain #yim:Chronostais equal to the number of turns experienced in this combat."
+      "Replaces #yBlizzard #yStaff. The first time you gain #yBlock each combat, double it. NL At the start of your turn, gain #yim:Chronostasis equal to the turn count."
     ]
   },
   "IceBreaker:MagicalScroll": {
     "NAME": "Magical Scroll",
-    "FLAVOR": "It looks like a recipe -- present from Ame.",
+    "FLAVOR": "It looks like a recipe. \n - Present from Ame.",
     "DESCRIPTIONS": [
-      "Choose #b1 of #b3 random #yim:Magic cards to add to your hand, it cost #b0 this turn."
+      "At the start of each combat, Choose #b1 of #b3 random #yim:Magic cards to add to your hand, it cost #b0 this turn."
     ]
   },
   "IceBreaker:Amulet": {
     "NAME": "Amulet",
-    "FLAVOR": "You can feel vitality is streaming in it -- present from Shiroikumo.",
+    "FLAVOR": "You can feel vitality flowing inside. \n - Present from Shiroikumo.",
     "DESCRIPTIONS": [
-      "The first time in combat you lose HP, heal #b8."
+      "Whenever you first lose HP each combat, heal #b8 HP."
     ]
   },
   "IceBreaker:Telescope": {
     "NAME": "Telescope",
-    "FLAVOR": "You can see the scenery in the distance……don't use it to peep the bath house -- present form Fukuhi.",
+    "FLAVOR": "You can see the scenery in the distance... Don't use it to peep the bath house. \n - Present form Fukuhi.",
     "DESCRIPTIONS": [
-      "At the start of your turn, draw #b1 less card , NL then choose a card from your draw pile to add into your hand."
+      "At the start of your turn, draw #b1 less card and choose a card from your draw pile to add into your hand."
     ]
   },
   "IceBreaker:Constellation": {
@@ -43,30 +43,30 @@
   },
   "IceBreaker:CrystalOfRadiance": {
     "NAME": "Crystal of Radiance",
-    "FLAVOR": "A knob of solidified radiance -- present from Brandy.",
+    "FLAVOR": "A star of solidified radiance. \n - Present from Brandy.",
     "DESCRIPTIONS": [
-      "Whenever you play a #ySpark outside of #yim:Chronogap , gain #b1 #yim:Chronostasis."
+      "Whenever you play a #ySpark outside of #yim:Chronogap [REMOVE_SPACE], gain #b1 #yim:Chronostasis [REMOVE_SPACE]."
     ]
   },
   "IceBreaker:EyeOfSpiritualView": {
     "NAME": "Eye of Soul",
-    "FLAVOR": "A small stone looks like an eye, you can catch the glimpse of magical power stream -- present from Disobey.",
+    "FLAVOR": "A small stone that looks like an eye, you can catch a glimpse of the magical power stream. \n - Present from Disobey.",
     "DESCRIPTIONS": [
-      "At the start of your turn, gain #b1 #yim:Resonance."
+      "At the start of your turn gain #b1 #yim:Resonance [REMOVE_SPACE]."
     ]
   },
   "IceBreaker:Letter": {
     "NAME": "Letter",
-    "FLAVOR": "\"The spire is spreading corrupt power.\" -- You can't be more familiar with the handwriting.",
+    "FLAVOR": "\"The spire is spreading corrupt power.\" - You can't be more familiar with the handwriting.",
     "DESCRIPTIONS": [
-      "Whenever you enter #yim:Chronogap , gain #b1 additional [E] and draw #b1 card."
+      "Upon entering #yim:Chronogap [REMOVE_SPACE], gain #b1 additional [E] and draw #b1 card."
     ]
   },
   "IceBreaker:ConnectionOfMeteor": {
     "NAME": "Connection of Meteor",
-    "FLAVOR": "Meteors across the night sky,the wishes at that time was \"accompany with you forever\".",
+    "FLAVOR": "Meteors across the night sky, that you wish will \n \"accompany you forever\".",
     "DESCRIPTIONS": [
-      "Upon pickup, Add #yim:Connect to #b1 Non-Connect card of Warrior in your deck.",
+      "Upon pickup, Add #yim:Connect to #b1 Non- [REMOVE_SPACE]#yConnect card of Zehhyo's color in your deck.",
       "Choose a card to add Connect."
     ]
   }

--- a/src/main/resources/localization/eng/IceBreaker-UIStrings.json
+++ b/src/main/resources/localization/eng/IceBreaker-UIStrings.json
@@ -11,7 +11,7 @@
   },
   "IceBreaker:DiscardPileToTopOfDeckAction": {
     "TEXT": [
-      "Choose no more than %d cards to put them on the top of your draw pile. "
+      "Choose up to %d cards to put them on the top of your draw pile."
     ]
   },
   "IceBreaker:SelectSpecifiedCardInHandAction": {


### PR DESCRIPTION
Significant improvements to `Eng` localisation.

39 items changed in CardStrings.
15 items changed in PowerStrings.
11 items changed in EventStrings.
9 items changed in RelicStrings.
8 items changed in KeywordStrings. (Addition of keyword: Unnate, does not affect `Zhs`). 
1 item changed in PotionStrings.
1 line fixed in CharacterStrings.
1 change in UIStrings.

Added missing PowerTip to `CrystalOfRadiance` (Spark). 
Fixed a bug where BloodyPath could interact with hidden powers (this causes compatability issues).

Suggestion added as comment in `Letter`.